### PR TITLE
Save thumbnails locally for later manipulation

### DIFF
--- a/code/DataObjects/YouTubeVideo.php
+++ b/code/DataObjects/YouTubeVideo.php
@@ -4,6 +4,18 @@
  * Class YouTubeVideo
  *
  * Represents a video on YouTube
+ *
+ * @property string Title
+ * @property string VideoID
+ * @property string Description
+ * @property SS_Datetime Published
+ * @property string ChannelTitle
+ * @property string ChannelID
+ * @property string PlaylistID
+ * @property string ThumbnailURL
+ * @property int PlaylistPosition
+ * @@property  int ThumbnailID
+ * @method Image Thumbnail
  */
 class YouTubeVideo extends DataObject
 {
@@ -21,6 +33,10 @@ class YouTubeVideo extends DataObject
         'PlaylistID' => 'Varchar(255)',
         'ThumbnailURL' => 'Varchar(255)',
         'PlaylistPosition' => 'Int',
+    );
+
+    private static $has_one = array(
+        'Thumbnail' => 'Image'
     );
 
     /**


### PR DESCRIPTION
This PR adds the ability to save thumbnails locally for use with SilverStripes `Image` functionality such as `CroppedImage`, `SetAspectRatio` etc

You can then reference the image via PHP: `$videoObject->Thumbnail()->URL()`
or via template: 

```
<% loop $YouTubeVideos %>
   $Thumbnail.CroppedImage(250,250).URL
<% end_loop %>
```